### PR TITLE
Using href attribute instead of the property

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function clickable(e) {
   if (el.target) return;
 
   // x-origin
-  if (url.isCrossDomain(el.href)) return;
+  if (url.isCrossDomain(el.getAttribute('href'))) return;
 
   return true;
 }


### PR DESCRIPTION
Using .href returns the full url with prototcol, port and all. This is cool, but it also means that isCrossDomain will always return true when you're on a https page.

`url.isCrossDomain` returns true when the current url is https and the link is an internal link. Something to do with comparing `location.port` (which is `""`) with an assumed port based on the protocol. 

Anyway, this fixes link-delegate for https pages.
